### PR TITLE
feat(app): reduce size of multiselects to improve performance

### DIFF
--- a/app/components/Ability.vue
+++ b/app/components/Ability.vue
@@ -6,8 +6,11 @@
     placeholder="Ability"
     :value="valueObj"
     :options="abilities"
+    :options-limit="20"
     @input="updateAbility"
-  />
+  >
+    <span slot="noResult">No Ability found.</span>
+  </multiselect>
 </template>
 
 <script>

--- a/app/components/Item.vue
+++ b/app/components/Item.vue
@@ -6,8 +6,11 @@
     placeholder="Item"
     :value="valueObj"
     :options="items"
+    :options-limit="20"
     @input="updateItem"
-  />
+  >
+    <span slot="noResult">No Item found.</span>
+  </multiselect>
 </template>
 
 <script>

--- a/app/components/Move.vue
+++ b/app/components/Move.vue
@@ -10,8 +10,11 @@
           placeholder="Move"
           :value="valueObj"
           :options="moves"
+          :options-limit="20"
           @input="updateMove"
-        />
+        >
+          <span slot="noResult">No Move found.</span>
+        </multiselect>
       </div>
 
       <div class="col-auto">

--- a/app/components/Nature.vue
+++ b/app/components/Nature.vue
@@ -7,7 +7,9 @@
     :value="valueObj"
     :options="natures"
     @input="updateNature"
-  />
+  >
+    <span slot="noResult">No Nature found.</span>
+  </multiselect>
 </template>
 
 <script>

--- a/app/components/SetSelector.vue
+++ b/app/components/SetSelector.vue
@@ -6,10 +6,12 @@
     group-label="pokemonName"
     :show-labels="false"
     placeholder="Pokemon"
-    :options="sets"
     :value="pokemon.set"
+    :options="sets"
+    :options-limit="20"
     @input="updatePokemon"
   >
+    <span slot="noResult">No Pokemon found.</span>
     <template slot="option" slot-scope="props">
       <span v-if="props.option.$isLabel">{{ props.option.$groupLabel }}</span>
       <span v-else>{{ props.option.setName }}</span>

--- a/app/components/Status.vue
+++ b/app/components/Status.vue
@@ -7,7 +7,9 @@
     :value="valueObj"
     :options="statuses"
     @input="updateStatus"
-  />
+  >
+    <span slot="noResult">No Status found.</span>
+  </multiselect>
 </template>
 
 <script>


### PR DESCRIPTION
vue-multiselect defaults to an `options-limit` of 1000 currently, so reduce the options to 20 whenever there are a significant number of options (n > 50 or so). No need to add to fixed option selects such as Nature and Status.